### PR TITLE
use sudo to fix permission issue

### DIFF
--- a/jmeter-scripts/getFootprint.sh
+++ b/jmeter-scripts/getFootprint.sh
@@ -1,7 +1,7 @@
 IP=${1}
 
 PID=$(ssh ${IP} ps -ef | grep java | grep -v grep | awk '{print $2}' | tail -1)
-FP=$(ssh ${IP} cat /proc/${PID}/smaps | grep 'Rss' | awk '{total+=$2;} END{print total;}' | numfmt --from-unit=1024 --to=iec | awk '{gsub("M"," "); print $1}')
+FP=$(ssh ${IP} sudo cat /proc/${PID}/smaps | grep 'Rss' | awk '{total+=$2;} END{print total;}' | numfmt --from-unit=1024 --to=iec | awk '{gsub("M"," "); print $1}')
 echo
 echo "Footprint: $FP"
 echo


### PR DESCRIPTION
 getFootprint.sh as part of run_pingPerf.sh does not have permission to cat a process due to the current runtime requirements for the SUT.  We think we can overcome this by using sudo in getFootprint.sh
```
... end of run
cat: /proc/437843/smaps: Permission denied
numfmt: invalid number: ‘’

Footprint: 
```