### PR TITLE
fix jmeter threads variable ref

### DIFF
--- a/jmeter-scripts/run_pingPerf.sh
+++ b/jmeter-scripts/run_pingPerf.sh
@@ -4,7 +4,7 @@ SUT=${2}
 sleep 5
 THREADS=100
 
-${JMETER_HOME}/bin/jmeter.sh -n -t simple.jmx -JHOST=${SUT} -JPORT=9090 -JTHREAD=100 -JDURATION=30 -JURL=/ping/greeting
+${JMETER_HOME}/bin/jmeter.sh -n -t simple.jmx -JHOST=${SUT} -JPORT=9090 -JTHREAD=${THREADS} -JDURATION=30 -JURL=/ping/greeting
 sleep 5
 ${JMETER_HOME}/bin/jmeter.sh -n -t simple.jmx -JHOST=${SUT} -JPORT=9090 -JTHREAD=${THREADS} -JDURATION=60 -JURL=/ping/greeting
 sleep 5


### PR DESCRIPTION
I think this was meant to be a reference to the THREADS local variable.